### PR TITLE
Fix Retrieval example

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ angle = AnglE.from_pretrained('WhereIsAI/UAE-Large-V1', pooling_strategy='cls').
 angle.set_prompt(prompt=Prompts.C)
 vec = angle.encode({'text': 'hello world'}, to_numpy=True)
 print(vec)
-vecs = angle.encode([{'text': 'hello world1', 'text': 'hello world2'}], to_numpy=True)
+vecs = angle.encode([{'text': 'hello world1'}, {'text': 'hello world2'}], to_numpy=True)
 print(vecs)
 ```
 


### PR DESCRIPTION
Change sending a list of one dictionary with save keys to a list of dictionaries.

From:
angle.encode([{'text': 'hello world1', 'text': 'hello world2'}], to_numpy=True)
Change to:
angle.encode([{'text': 'hello world1'}, {'text': 'hello world2'}], to_numpy=True)

Now we are getting the output shape (2, 1024) rather than (1, 1024).
