### PR TITLE
Added argument to explicitly pass device to class constructor

### DIFF
--- a/angle_emb/angle.py
+++ b/angle_emb/angle.py
@@ -454,14 +454,18 @@ class AnglE:
                  pretrained_lora_path: Optional[str] = None,
                  apply_bfloat16: Optional[bool] = None,
                  torch_dtype: Optional[torch.dtype] = None,
+                 device: Optional[str]=None,
                  **kwargs: Any):
         super().__init__()
         self.max_length = max_length
         self.train_mode = train_mode
         self.pooling_strategy = pooling_strategy
-        self.device = set_device()
         self.load_kbit = load_kbit
         self.is_llm = is_llm
+        if device:
+            self.device=device
+        else:
+            self.device = set_device()
         if is_llm is None:
             self.is_llm = self.check_llm(model_name_or_path)
             if self.is_llm:


### PR DESCRIPTION
It will override set_device method if device is passed if not passed it will use set_device method
valid devices just like set_device are "cpu", "mps" and "cuda"
example usage
model = AnglE.from_pretrained(instructor_model_name, pooling_strategy='cls',device="cpu")
