### PR TITLE
remove torch_dtype for AutoModel

### DIFF
--- a/angle_emb/angle.py
+++ b/angle_emb/angle.py
@@ -1313,8 +1313,7 @@ class AnglE:
                     logger.info(f'Load pretrained model from {pretrained_model_path}')
                 self.backbone = AutoModel.from_pretrained(
                     pretrained_model_path or model_name_or_path,
-                    trust_remote_code=True,
-                    torch_dtype=torch_dtype or "auto")
+                    trust_remote_code=True)
 
         if train_mode and self.apply_lora:
             self.backbone.print_trainable_parameters()


### PR DESCRIPTION
When loading some BERT-based models with AutoModel, NaN values are produced if torch_dtype is specified to 'auto'. Remove torch_dtype here to fix this bug.