### PR TITLE
Fix for possibly incorrect mean pooling

### DIFF
--- a/angle_emb/angle.py
+++ b/angle_emb/angle.py
@@ -272,8 +272,7 @@ def get_pooling(outputs: torch.Tensor,
         sequence_lengths = -1 if padding_side == 'left' else inputs["attention_mask"].sum(dim=1) - 1
         outputs = outputs[torch.arange(batch_size, device=outputs.device), sequence_lengths]
     elif pooling_strategy == 'avg':
-        outputs = torch.sum(
-            outputs * inputs["attention_mask"][:, :, None], dim=1) / torch.sum(inputs["attention_mask"])
+        outputs = torch.sum(outputs * inputs["attention_mask"][:, :, None], dim=1) / inputs["attention_mask"].sum(dim=1).unsqueeze(1)
     elif pooling_strategy == 'max':
         outputs, _ = torch.max(outputs * inputs["attention_mask"][:, :, None], dim=1)
     elif pooling_strategy == 'all':


### PR DESCRIPTION
Hi,

this is the fix for issue https://github.com/SeanLee97/AnglE/issues/101, (in case it truly is incorrect). To the best of my knowledge, the current code sums over the whole attention mask tensor, instead of keeping dimension zero intact, and summing only over the first dimension.